### PR TITLE
Remove "Comprar entradas" from header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,9 +61,6 @@
               <a class="nav-link" href="#faq">Que es un PyCamp?</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="#buy-now">Comprar entradas</a>
-            </li>
-            <li class="nav-item">
               <a class="nav-link" href="#deckk">Proyectos</a>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
This section is not too important to be there since it's the first thing that appears in the web when you open it anyways. We can use this space for another section.