### PR TITLE
Initial implementation to scroll to anchor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { HashRouter, Routes, Route } from "react-router-dom";
 import ScrollToTop from "./components/ScrollToTop/ScrollToTop";
+import ScrollToAnchor from "./components/ScrollToAnchor/ScrollToAnchor";
 
 import Home from "./pages/Home/Home";
 import Event from "./pages/Event/Event";
@@ -10,6 +11,7 @@ import PreviousEditions from "./pages/PreviousEditions/PreviousEditions";
 function App() {
   return (
     <HashRouter>
+      <ScrollToAnchor />
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/components/ScrollToAnchor/ScrollToAnchor.jsx
+++ b/src/components/ScrollToAnchor/ScrollToAnchor.jsx
@@ -1,0 +1,27 @@
+// Borrowed from https://dev.to/mindactuate/scroll-to-anchor-element-with-react-router-v6-38op
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+function ScrollToAnchor() {
+  const location = useLocation();
+  const lastHash = useRef('');
+
+  useEffect(() => {
+    if (location.hash) {
+      lastHash.current = location.hash.slice(1);
+    }
+
+    if (lastHash.current && document.getElementById(lastHash.current)) {
+      setTimeout(() => {
+        document
+          .getElementById(lastHash.current)
+          ?.scrollIntoView({ behavior: "smooth", block: 'center' });
+        lastHash.current = '';
+      }, 100);
+    }
+  }, [location]);
+
+  return null;
+}
+
+export default ScrollToAnchor;

--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -2,15 +2,17 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 function ScrollToTop() {
-  const { pathname } = useLocation();
+  const location = useLocation();
 
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      left: 0,
-      behavior: "auto", 
-    });
-  }, [pathname]);
+    if (!location.hash) {
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: "instant", 
+      });
+    }
+  }, [location]);
 
   return null;
 }

--- a/src/pages/Faqs/Faqs.jsx
+++ b/src/pages/Faqs/Faqs.jsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { use, useState } from "react";
+import { useLocation } from 'react-router-dom';
 import Navbar from "../../components/Navbar/Navbar";
 import Button from "../../components/Button/Button";
 import CTA from "../../components/CTA/CTA";
@@ -7,7 +8,13 @@ import questionIcon from "../../assets/icons/question-circle.svg";
 import "./Faqs.css";
 
 function Faqs() {
-  const [openAccordion, setOpenAccordion] = useState(0);
+  let selectedFaq = 0;
+  const location = useLocation();
+  if (location.hash) {
+    selectedFaq = parseInt(location.hash.slice(1));
+  }
+
+  const [openAccordion, setOpenAccordion] = useState(selectedFaq);
 
   const toggleAccordion = (index) => {
     setOpenAccordion(openAccordion === index ? null : index);
@@ -163,6 +170,7 @@ function Faqs() {
             <div className="faqs-accordion">
               {faqs.map((faq, index) => (
                 <article
+                  id={index}
                   key={index}
                   className={`faq-item ${openAccordion === index ? "active" : ""}`}
                 >


### PR DESCRIPTION
URLs like this will work:

- https://pycamp.es/2026/#/faqs#3
- https://pycamp.es/2026/#/event#project-idea

There is more work I'd like to do here, but this is just the start:

- Add more ids to elements on different pages so we can easily point to them
- Update the URL when clicking on FAQs so it reflects the current FAQ being opened