### PR TITLE
Allow serving `/2027/index.html` as `/index.html` for the year 2027.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,10 @@ export const routes = [
     element: <Layout />,
     children: [
       { index: true, element: <Home /> },
+      // Allow the literal /index.html URL to render the same Home page.
+      // React Router strips the basename (e.g. /2027/) and is left with
+      // "/index.html", which otherwise wouldn't match any route.
+      { path: "index.html", element: <Home /> },
       { path: "event", element: <Event /> },
       { path: "diversity", element: <Diversity /> },
       { path: "faqs", element: <Faqs /> },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { Navigate } from "react-router-dom";
 import Layout from "./Layout.jsx";
 import Home from "./pages/Home/Home";
 import Event from "./pages/Event/Event";
@@ -11,10 +12,10 @@ export const routes = [
     element: <Layout />,
     children: [
       { index: true, element: <Home /> },
-      // Allow the literal /index.html URL to render the same Home page.
-      // React Router strips the basename (e.g. /2027/) and is left with
-      // "/index.html", which otherwise wouldn't match any route.
-      { path: "index.html", element: <Home /> },
+      // Redirect the literal /index.html URL to the home page. React Router
+      // strips the basename (e.g. /2027/) and is left with "/index.html",
+      // which otherwise wouldn't match any route.
+      { path: "index.html", element: <Navigate to="/" replace /> },
       { path: "event", element: <Event /> },
       { path: "diversity", element: <Diversity /> },
       { path: "faqs", element: <Faqs /> },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+import { copyFileSync, existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
@@ -15,16 +17,23 @@ export default defineConfig({
   },
   ssgOptions: {
     dirStyle: "nested",
-    // The "index.html" route only exists so React Router can match the
-    // literal /index.html URL at runtime; the physical file already comes
-    // from the index route, so skip pre-rendering it (it would collide with
-    // dist/index.html and fail with EISDIR).
-    includedRoutes: (paths) => paths.filter((path) => path !== "index.html"),
+    // Control which routes get pre-rendered to static files. This replaces
+    // vite-react-ssg's default filter, so we must reproduce it:
+    //   - drop "*" / ":" routes (the catch-all and any dynamic params), which
+    //     have no single concrete URL to render;
+    //   - drop "index.html", whose physical file already comes from the index
+    //     route — rendering it would collide with dist/index.html (EISDIR).
+    includedRoutes: (paths) =>
+      paths.filter(
+        (path) =>
+          !path.includes("*") &&
+          !path.includes(":") &&
+          path !== "index.html"
+      ),
 
     // With dirStyle "nested" the "404" route is pre-rendered to 404/index.html,
     // but Read the Docs serves the file named 404.html for unknown URLs, so we
-    // copy it there once the build is done. The "*" catch-all route is skipped
-    // by vite-react-ssg's default includedRoutes (it ignores wildcard paths).
+    // copy it there once the build is done.
     onFinished: (outDir) => {
       const out = isAbsolute(outDir) ? outDir : resolve(process.cwd(), outDir);
       const source = join(out, "404", "index.html");

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,5 +15,10 @@ export default defineConfig({
   },
   ssgOptions: {
     dirStyle: "nested",
+    // The "index.html" route only exists so React Router can match the
+    // literal /index.html URL at runtime; the physical file already comes
+    // from the index route, so skip pre-rendering it (it would collide with
+    // dist/index.html and fail with EISDIR).
+    includedRoutes: (paths) => paths.filter((path) => path !== "index.html"),
   },
 });


### PR DESCRIPTION
This page fails currently https://pycamp.es/2027/index.html

This commit adds the index.html route to serve the same page as /2027/